### PR TITLE
Adding notes objects to be retrieved with base post class

### DIFF
--- a/TumblrSharp.Client/BaseNote.cs
+++ b/TumblrSharp.Client/BaseNote.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace DontPanic.TumblrSharp.Client
+{
+	/// <summary>
+	/// Base class for post notes.
+	/// </summary>
+	public class BaseNote
+	{
+		/// <summary>
+		/// The type of note applied to the post
+		/// </summary>
+		[JsonConverter(typeof(EnumConverter))]
+		[JsonProperty(PropertyName = "type")]
+		public NoteType Type { get; set; }
+
+		/// <summary>
+		/// The date and time of the post (in local time).
+		/// </summary>
+		[JsonConverter(typeof(TimestampConverter))]
+		[JsonProperty(PropertyName = "timestamp")]
+		public DateTime Timestamp { get; set; }
+
+		/// <summary>
+		/// The short name used to uniquely identify a blog.
+		/// </summary>
+		[JsonProperty(PropertyName = "blog_name")]
+		public string BlogName { get; set; }
+		
+		/// <summary>
+		/// The full domain used to uniquely identify a blog.
+		/// </summary>
+		[JsonProperty(PropertyName = "blog_uuid")]
+		public string BlogUuid { get; set; }
+		
+		/// <summary>
+		/// The base URL of the blog that left the note
+		/// </summary>
+		[JsonProperty(PropertyName = "blog_url")]
+		public string BlogUrl { get; set; }
+
+		/// <summary>
+		/// Indicates if the current user is following 
+		/// the blog who left the post
+		/// </summary>
+		[JsonProperty(PropertyName = "followed")]
+		public bool Followed { get; set; }
+		
+		/// <summary>
+		/// The avatar shape used by the blog that
+		/// left the note
+		/// </summary>
+		[JsonConverter(typeof(EnumConverter))]
+		[JsonProperty(PropertyName = "avatar_shape")]
+		public AvatarShape AvatarShape { get; set; }
+
+		/// <summary>
+		/// The text of the note if it is a reply
+		/// </summary>
+		[JsonProperty(PropertyName = "reply_text")]
+		public string ReplyText { get; set; }
+
+		/// <summary>
+		/// The post ID of the reblogged post
+		/// if the note is a reblog
+		/// </summary>
+		[JsonProperty(PropertyName = "post_id")]
+		public string PostId { get; set; }
+
+		/// <summary>
+		/// The parent blog of the reblogged post
+		/// if the note is a reblog
+		/// </summary>
+		[JsonProperty(PropertyName = "reblog_parent_blog_name")]
+		public string ReblogParentBlogName { get; set; }
+	}
+}

--- a/TumblrSharp.Client/BasePost.cs
+++ b/TumblrSharp.Client/BasePost.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 
 namespace DontPanic.TumblrSharp.Client
 {
@@ -45,6 +46,12 @@ namespace DontPanic.TumblrSharp.Client
 		/// </summary>
         [JsonProperty(PropertyName = "note_count")]
         public long NotesCount { get; set; }
+
+	    /// <summary>
+	    /// The notes (likes and reblogs) for the post
+	    /// </summary>
+		[JsonProperty(PropertyName = "notes")]
+		public List<BaseNote> Notes { get; set; }
 
 		/// <summary>
 		/// The <see cref="PostFormat"/>.

--- a/TumblrSharp.Client/TumblrSharp.Client.csproj
+++ b/TumblrSharp.Client/TumblrSharp.Client.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="AnswerPost.cs" />
     <Compile Include="AudioPost.cs" />
+    <Compile Include="BaseNote.cs" />
     <Compile Include="BasePost.cs" />
     <Compile Include="BlogBase.cs" />
     <Compile Include="BlogInfo.cs" />

--- a/TumblrSharp.sln
+++ b/TumblrSharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TumblrSharp", "TumblrSharp\TumblrSharp.csproj", "{4A8B7B77-F7AE-4155-9E9C-253AFD6E0C3A}"
 EndProject

--- a/TumblrSharp/AvatarShape.cs
+++ b/TumblrSharp/AvatarShape.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DontPanic.TumblrSharp
+{	
+	/// <summary>
+	/// Options for what shape a user's avatar is 
+	/// intended to display as
+	/// </summary>
+	public enum AvatarShape
+	{
+		/// <summary>
+		/// Square avatar
+		/// </summary>
+		Square = 0,
+		/// <summary>
+		/// Circular avatar
+		/// </summary>
+		Circle = 1
+	}
+}

--- a/TumblrSharp/NoteType.cs
+++ b/TumblrSharp/NoteType.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DontPanic.TumblrSharp
+{
+	/// <summary>
+	/// Defines the type of note on a post
+	/// </summary>
+	public enum NoteType
+	{
+		Posted = 0,
+		Reblog = 1,
+		Like = 2,
+		Reply = 3
+	}
+}

--- a/TumblrSharp/TumblrSharp.csproj
+++ b/TumblrSharp/TumblrSharp.csproj
@@ -40,6 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ApiMethod.cs" />
+    <Compile Include="AvatarShape.cs" />
     <Compile Include="BinaryFile.cs" />
     <Compile Include="BinaryMethodParameter.cs" />
     <Compile Include="BlogMethod.cs" />
@@ -50,6 +51,7 @@
     <Compile Include="IMethodParameter.cs" />
     <Compile Include="ITumblrClientFactory.cs" />
     <Compile Include="MethodParameterSet.cs" />
+    <Compile Include="NoteType.cs" />
     <Compile Include="OAuth\IOAuthClientFactory.cs" />
     <Compile Include="OAuth\OAuthClient.cs" />
     <Compile Include="OAuth\OAuthClientFactory.cs" />


### PR DESCRIPTION
Hello! I'm in need of your library for a fairly urgent update to a site I run to allow it to interact with Tumblr's OAuth flow; however, discovered in the process that you don't yet have the notes objects populated when mapping from Tumblr's responses, which I also need. Took the liberty of adding it myself for a PR; fairly simple object structure update and Newtonsoft does most of the work, but let me know if you need any further updates on my end!