### PR TITLE
get likes using "before" and "after" parameters, plus code indentation stuff

### DIFF
--- a/TumblrSharp.Client/TumblrClient.cs
+++ b/TumblrSharp.Client/TumblrClient.cs
@@ -263,128 +263,137 @@ namespace DontPanic.TumblrSharp.Client
 				CancellationToken.None);
 		}
 
-		#endregion
+    #endregion
 
-		#region GetBlogLikesAsync
+    #region GetBlogLikesAsync
 
-		/// <summary>
-		/// Asynchronously retrieves the publicly exposed likes from a blog.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#blog-likes
-		/// </remarks>
-		/// <param name="blogName">
-		/// The name of the blog.
-		/// </param>
-		/// <param name="startIndex">
-		/// The offset at which to start retrieving the likes. Use 0 to start retrieving from the latest like.
-		/// </param>
-		/// <param name="count">
-		/// The number of likes to retrieve. Must be between 1 and 20.
-		/// </param>
-		/// <returns>
-		/// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-		/// carry a <see cref="Likes"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
-		/// representing the error occurred during the call.
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="blogName"/> is <b>null</b>.
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <paramref name="blogName"/> is empty.
-		/// </exception>
-		/// <exception cref="System.ArgumentOutOfRangeException">
-		/// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="startIndex"/> is less than 0.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="count"/> is less than 1 or greater than 20.
-		///		</description>
-		///	</item>
-		/// </list>
-		/// </exception>
-		public Task<Likes> GetBlogLikesAsync(string blogName, int startIndex = 0, int count = 20)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+    /// <summary>
+    /// Asynchronously retrieves the publicly exposed likes from a blog.
+    /// </summary>
+    /// <remarks>
+    /// See: http://www.tumblr.com/docs/en/api/v2#blog-likes
+    /// </remarks>
+    /// <param name="blogName">
+    /// The name of the blog.
+    /// </param>
+    /// <param name="startIndex">
+    /// The offset at which to start retrieving the likes. Use 0 to start retrieving from the latest like.
+    /// </param>
+    /// <param name="count">
+    /// The number of likes to retrieve. Must be between 1 and 20.
+    /// </param>
+    /// <param name="before">
+    /// The timestamp before when to retrieve likes. 
+    /// </param>
+    /// <param name="after">
+    /// The timestamp after when to retrieve likes. 
+    /// </param>
+    /// <returns>
+    /// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+    /// carry a <see cref="Likes"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
+    /// representing the error occurred during the call.
+    /// </returns>
+    /// <exception cref="ObjectDisposedException">
+    /// The object has been disposed.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="blogName"/> is <b>null</b>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="blogName"/> is empty.
+    /// </exception>
+    /// <exception cref="System.ArgumentOutOfRangeException">
+    /// <list type="bullet">
+    /// <item>
+    ///		<description>
+    ///			<paramref name="startIndex"/> is less than 0.
+    ///		</description>
+    ///	</item>
+    ///	<item>
+    ///		<description>
+    ///			<paramref name="count"/> is less than 1 or greater than 20.
+    ///		</description>
+    ///	</item>
+    /// </list>
+    /// </exception>
+    public Task<Likes> GetBlogLikesAsync(string blogName, int startIndex = 0, int count = 20, DateTime? before = null, DateTime? after = null)
+    {
+      if (disposed)
+        throw new ObjectDisposedException("TumblrClient");
 
-			if (blogName == null)
-				throw new ArgumentNullException("blogName");
+      if (blogName == null)
+        throw new ArgumentNullException("blogName");
 
-			if (blogName.Length == 0)
-				throw new ArgumentException("Blog name cannot be empty.", "blogName");
+      if (blogName.Length == 0)
+        throw new ArgumentException("Blog name cannot be empty.", "blogName");
 
-			if (startIndex < 0)
-				throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
+      if (startIndex < 0)
+        throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
 
-			if (count < 1 || count > 20)
-				throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
+      if (count < 1 || count > 20)
+        throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("api_key", apiKey);
-			parameters.Add("offset", startIndex, 0);
-			parameters.Add("limit", count, 0);
+      MethodParameterSet parameters = new MethodParameterSet
+      {
+        { "api_key", apiKey },
+        { "offset", startIndex, 0 },
+        { "limit", count, 0 },
+        { "before", before.HasValue ? DateTimeHelper.ToTimestamp(before.Value).ToString() : null, null },
+        { "after", after.HasValue ? DateTimeHelper.ToTimestamp(after.Value).ToString() : null, null }
+      };
 
-			return CallApiMethodAsync<Likes>(
-				new BlogMethod(blogName, "likes", null, HttpMethod.Get, parameters),
-				CancellationToken.None);
-		}
+      return CallApiMethodAsync<Likes>(
+        new BlogMethod(blogName, "likes", null, HttpMethod.Get, parameters),
+        CancellationToken.None);
+    }
+    #endregion
 
-		#endregion
+    #region GetFollowersAsync
 
-		#region GetFollowersAsync
-
-		/// <summary>
-		/// Asynchronously retrieves a blog's followers.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#blog-followers
-		/// </remarks>
-		/// <param name="blogName">
-		/// The name of the blog.
-		/// </param>
-		/// <param name="startIndex">
-		/// The offset at which to start retrieving the followers. Use 0 to start retrieving from the latest follower.
-		/// </param>
-		/// <param name="count">
-		/// The number of followers to retrieve. Must be between 1 and 20.
-		/// </param>
-		/// <returns>
-		///  A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-		/// carry a <see cref="Followers"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
-		/// A <see cref="Followers"/> instance.
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="blogName"/> is <b>null</b>.
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <paramref name="blogName"/> is empty.
-		/// </exception>
-		/// <exception cref="System.ArgumentOutOfRangeException">
-		/// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="startIndex"/> is less than 0.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="count"/> is less than 1 or greater than 20.
-		///		</description>
-		///	</item>
-		/// </list>
-		/// </exception>
-		public Task<Followers> GetFollowersAsync(string blogName, int startIndex = 0, int count = 20)
+    /// <summary>
+    /// Asynchronously retrieves a blog's followers.
+    /// </summary>
+    /// <remarks>
+    /// See: http://www.tumblr.com/docs/en/api/v2#blog-followers
+    /// </remarks>
+    /// <param name="blogName">
+    /// The name of the blog.
+    /// </param>
+    /// <param name="startIndex">
+    /// The offset at which to start retrieving the followers. Use 0 to start retrieving from the latest follower.
+    /// </param>
+    /// <param name="count">
+    /// The number of followers to retrieve. Must be between 1 and 20.
+    /// </param>
+    /// <returns>
+    ///  A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+    /// carry a <see cref="Followers"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
+    /// A <see cref="Followers"/> instance.
+    /// </returns>
+    /// <exception cref="ObjectDisposedException">
+    /// The object has been disposed.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="blogName"/> is <b>null</b>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="blogName"/> is empty.
+    /// </exception>
+    /// <exception cref="System.ArgumentOutOfRangeException">
+    /// <list type="bullet">
+    /// <item>
+    ///		<description>
+    ///			<paramref name="startIndex"/> is less than 0.
+    ///		</description>
+    ///	</item>
+    ///	<item>
+    ///		<description>
+    ///			<paramref name="count"/> is less than 1 or greater than 20.
+    ///		</description>
+    ///	</item>
+    /// </list>
+    /// </exception>
+    public Task<Followers> GetFollowersAsync(string blogName, int startIndex = 0, int count = 20)
 		{
 			if (disposed)
 				throw new ObjectDisposedException("TumblrClient");
@@ -1273,48 +1282,54 @@ namespace DontPanic.TumblrSharp.Client
 				CancellationToken.None);
 		}
 
-        #endregion
+    #endregion
 
-        #region GetLikesAsync
+    #region GetLikesAsync
 
-        /// <summary>
-        /// Asynchronously retrieves the current user's likes.
-        /// </summary>
-        /// <remarks>
-        /// See: http://www.tumblr.com/docs/en/api/v2#m-ug-likes
-        /// </remarks>
-        /// <param name="startIndex">
-        /// The offset at which to start retrieving the likes. Use 0 to start retrieving from the latest like.
-        /// </param>
-        /// <param name="count">
-        /// The number of likes to retrieve. Must be between 1 and 20.
-        /// </param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-        /// carry a <see cref="Likes"/> instance. Otherwise <see cref="Task.Exception"/> will carry the <see cref="TumblrException"/>
-        /// generated during the call.
-        /// </returns>
-        /// <exception cref="ObjectDisposedException">
-        /// The object has been disposed.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
-        /// </exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">
-        /// <list type="bullet">
-        /// <item>
-        ///		<description>
-        ///			<paramref name="startIndex"/> is less than 0.
-        ///		</description>
-        ///	</item>
-        ///	<item>
-        ///		<description>
-        ///			<paramref name="count"/> is less than 1 or greater than 20.
-        ///		</description>
-        ///	</item>
-        /// </list>
-        /// </exception>
-        public Task<Likes> GetLikesAsync(long startIndex = 0, int count = 20)
+    /// <summary>
+    /// Asynchronously retrieves the current user's likes.
+    /// </summary>
+    /// <remarks>
+    /// See: http://www.tumblr.com/docs/en/api/v2#m-ug-likes
+    /// </remarks>
+    /// <param name="startIndex">
+    /// The offset at which to start retrieving the likes. Use 0 to start retrieving from the latest like.
+    /// </param>
+    /// <param name="count">
+    /// The number of likes to retrieve. Must be between 1 and 20.
+    /// </param>
+    /// <param name="before">
+    /// The timestamp before when to retrieve likes. 
+    /// </param>
+    /// <param name="after">
+    /// The timestamp after when to retrieve likes. 
+    /// </param>
+    /// <returns>
+    /// A <see cref="Task"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+    /// carry a <see cref="Likes"/> instance. Otherwise <see cref="Task.Exception"/> will carry the <see cref="TumblrException"/>
+    /// generated during the call.
+    /// </returns>
+    /// <exception cref="ObjectDisposedException">
+    /// The object has been disposed.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
+    /// </exception>
+    /// <exception cref="System.ArgumentOutOfRangeException">
+    /// <list type="bullet">
+    /// <item>
+    ///		<description>
+    ///			<paramref name="startIndex"/> is less than 0.
+    ///		</description>
+    ///	</item>
+    ///	<item>
+    ///		<description>
+    ///			<paramref name="count"/> is less than 1 or greater than 20.
+    ///		</description>
+    ///	</item>
+    /// </list>
+    /// </exception>
+    public Task<Likes> GetLikesAsync(long startIndex = 0, int count = 20, DateTime? before = null, DateTime? after = null)
 		{
 			if (disposed)
 				throw new ObjectDisposedException("TumblrClient");
@@ -1328,11 +1343,15 @@ namespace DontPanic.TumblrSharp.Client
 			if (OAuthToken == null)
 				throw new InvalidOperationException("GetLikesAsync method requires an OAuth token to be specified.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("offset", startIndex, 0);
-			parameters.Add("limit", count, 0);
+      MethodParameterSet parameters = new MethodParameterSet
+      {
+        { "offset", startIndex, 0 },
+        { "limit", count, 0 },
+        { "before", before.HasValue ? DateTimeHelper.ToTimestamp(before.Value).ToString() : null, null },
+        { "after", after.HasValue ? DateTimeHelper.ToTimestamp(after.Value).ToString() : null, null }
+      };
 
-			return CallApiMethodAsync<Likes>(
+      return CallApiMethodAsync<Likes>(
 				new UserMethod("likes", OAuthToken, HttpMethod.Get, parameters),
 				CancellationToken.None);
 		}

--- a/TumblrSharp.Client/TumblrClient.cs
+++ b/TumblrSharp.Client/TumblrClient.cs
@@ -8,332 +8,332 @@ using System.Linq;
 
 namespace DontPanic.TumblrSharp.Client
 {
-	/// <summary>
-	/// Encapsulates the Tumblr API.
-	/// </summary>
-	public class TumblrClient : TumblrClientBase
-	{
-		private bool disposed;
-		private readonly string apiKey;
-		
-		/// <summary>
-		/// Initializes a new instance of the <see cref="TumblrClient"/> class.
-		/// </summary>
+    /// <summary>
+    /// Encapsulates the Tumblr API.
+    /// </summary>
+    public class TumblrClient : TumblrClientBase
+    {
+        private bool disposed;
+        private readonly string apiKey;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TumblrClient"/> class.
+        /// </summary>
         /// <param name="hashProvider">
         /// A <see cref="IHmacSha1HashProvider"/> implementation used to generate a
         /// HMAC-SHA1 hash for OAuth purposes.
         /// </param>
-		/// <param name="consumerKey">
-		/// The consumer key.
-		/// </param>
-		/// <param name="consumerSecret">
-		/// The consumer secret.
-		/// </param>
-		/// <param name="oAuthToken">
-		/// An optional access token for the API. If no access token is provided, only the methods
-		/// that do not require OAuth can be invoked successfully.
-		/// </param>
-		/// <remarks>
-		///  You can get a consumer key and a consumer secret by registering an application with Tumblr:<br/>
-		/// <br/>
-		/// http://www.tumblr.com/oauth/apps
-		/// </remarks>
+        /// <param name="consumerKey">
+        /// The consumer key.
+        /// </param>
+        /// <param name="consumerSecret">
+        /// The consumer secret.
+        /// </param>
+        /// <param name="oAuthToken">
+        /// An optional access token for the API. If no access token is provided, only the methods
+        /// that do not require OAuth can be invoked successfully.
+        /// </param>
+        /// <remarks>
+        ///  You can get a consumer key and a consumer secret by registering an application with Tumblr:<br/>
+        /// <br/>
+        /// http://www.tumblr.com/oauth/apps
+        /// </remarks>
         public TumblrClient(IHmacSha1HashProvider hashProvider, string consumerKey, string consumerSecret, Token oAuthToken = null)
-			: base(hashProvider, consumerKey, consumerSecret, oAuthToken)
-		{
-			this.apiKey = consumerKey; 
-		}
+      : base(hashProvider, consumerKey, consumerSecret, oAuthToken)
+        {
+            this.apiKey = consumerKey;
+        }
 
-		#region Public Methods
+        #region Public Methods
 
-		#region Blog Methods
+        #region Blog Methods
 
-		#region GetBlogInfoAsync
+        #region GetBlogInfoAsync
 
-		/// <summary>
-		/// Asynchronously retrieves general information about the blog, such as the title, number of posts, and other high-level data.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#blog-info.
-		/// </remarks>
-		/// <param name="blogName">
-		/// The name of the blog.
-		/// </param>
-		/// <returns>
-		/// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-		/// carry a <see cref="BlogInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
-		/// representing the error occurred during the call.
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="blogName"/> is <b>null</b>.
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <paramref name="blogName"/> is empty.
-		/// </exception>
-		public Task<BlogInfo> GetBlogInfoAsync(string blogName)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        /// <summary>
+        /// Asynchronously retrieves general information about the blog, such as the title, number of posts, and other high-level data.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#blog-info.
+        /// </remarks>
+        /// <param name="blogName">
+        /// The name of the blog.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="BlogInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
+        /// representing the error occurred during the call.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="blogName"/> is <b>null</b>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="blogName"/> is empty.
+        /// </exception>
+        public Task<BlogInfo> GetBlogInfoAsync(string blogName)
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (blogName == null)
-				throw new ArgumentNullException("blogName");
+            if (blogName == null)
+                throw new ArgumentNullException("blogName");
 
-			if (blogName.Length == 0)
-				throw new ArgumentException("Blog name cannot be empty.", "blogName");
+            if (blogName.Length == 0)
+                throw new ArgumentException("Blog name cannot be empty.", "blogName");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("api_key", apiKey);
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("api_key", apiKey);
 
-			return CallApiMethodAsync<BlogInfoResponse, BlogInfo>(
-				new BlogMethod(blogName, "info", OAuthToken, HttpMethod.Get, parameters),
-				r => r.Blog,
-				CancellationToken.None);
-		}
+            return CallApiMethodAsync<BlogInfoResponse, BlogInfo>(
+              new BlogMethod(blogName, "info", OAuthToken, HttpMethod.Get, parameters),
+              r => r.Blog,
+              CancellationToken.None);
+        }
 
-		#endregion
+        #endregion
 
-		#region GetPostsAsync
+        #region GetPostsAsync
 
-		/// <summary>
-		/// Asynchronously retrieves published posts from a blog.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#posts
-		/// </remarks>
-		/// <param name="blogName">
-		/// The name of the blog.
-		/// </param>
-		/// <param name="startIndex">
-		/// The offset at which to start retrieving the posts. Use 0 to start retrieving from the latest post.
-		/// </param>
-		/// <param name="count">
-		/// The number of posts to retrieve. Must be between 1 and 20.
-		/// </param>
-		/// <param name="type">
-		/// The <see cref="PostType"/> to retrieve.
-		/// </param>
-		/// <param name="includeReblogInfo">
-		/// Whether or not to include reblog info with the posts.
-		/// </param>
-		/// <param name="includeNotesInfo">
-		/// Whether or not to include notes info with the posts.
-		/// </param>
-		/// <param name="filter">
-		/// A <see cref="PostFilter"/> to apply.
-		/// </param>
-		/// <param name="tag">
-		/// A tag to filter by.
-		/// </param>
-		/// <returns>
-		/// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-		/// carry a <see cref="Posts"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
-		/// representing the error occurred during the call.
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="blogName"/> is <b>null</b>.
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <paramref name="blogName"/> is empty.
-		/// </exception>
-		/// <exception cref="System.ArgumentOutOfRangeException">
-		/// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="startIndex"/> is less than 0.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="count"/> is less than 1 or greater than 20.
-		///		</description>
-		///	</item>
-		/// </list>
-		/// </exception>
-		public Task<Posts> GetPostsAsync(string blogName, long startIndex = 0, int count = 20, PostType type = PostType.All, bool includeReblogInfo = false, bool includeNotesInfo = false, PostFilter filter = PostFilter.Html, string tag = null)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        /// <summary>
+        /// Asynchronously retrieves published posts from a blog.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#posts
+        /// </remarks>
+        /// <param name="blogName">
+        /// The name of the blog.
+        /// </param>
+        /// <param name="startIndex">
+        /// The offset at which to start retrieving the posts. Use 0 to start retrieving from the latest post.
+        /// </param>
+        /// <param name="count">
+        /// The number of posts to retrieve. Must be between 1 and 20.
+        /// </param>
+        /// <param name="type">
+        /// The <see cref="PostType"/> to retrieve.
+        /// </param>
+        /// <param name="includeReblogInfo">
+        /// Whether or not to include reblog info with the posts.
+        /// </param>
+        /// <param name="includeNotesInfo">
+        /// Whether or not to include notes info with the posts.
+        /// </param>
+        /// <param name="filter">
+        /// A <see cref="PostFilter"/> to apply.
+        /// </param>
+        /// <param name="tag">
+        /// A tag to filter by.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="Posts"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
+        /// representing the error occurred during the call.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="blogName"/> is <b>null</b>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="blogName"/> is empty.
+        /// </exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="startIndex"/> is less than 0.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="count"/> is less than 1 or greater than 20.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        public Task<Posts> GetPostsAsync(string blogName, long startIndex = 0, int count = 20, PostType type = PostType.All, bool includeReblogInfo = false, bool includeNotesInfo = false, PostFilter filter = PostFilter.Html, string tag = null)
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (blogName == null)
-				throw new ArgumentNullException("blogName");
+            if (blogName == null)
+                throw new ArgumentNullException("blogName");
 
-			if (blogName.Length == 0)
-				throw new ArgumentException("Blog name cannot be empty.", "blogName");
+            if (blogName.Length == 0)
+                throw new ArgumentException("Blog name cannot be empty.", "blogName");
 
-			if (startIndex < 0)
-				throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
 
-			if (count < 1 || count > 20)
-				throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
+            if (count < 1 || count > 20)
+                throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
 
-			string methodName = null;
-			switch (type)
-			{
-				case PostType.Text: methodName = "posts/text"; break;
-				case PostType.Quote: methodName = "posts/quote"; break;
-				case PostType.Link: methodName = "posts/link"; break;
-				case PostType.Answer: methodName = "posts/answer"; break;
-				case PostType.Video: methodName = "posts/video"; break;
-				case PostType.Audio: methodName = "posts/audio"; break;
-				case PostType.Photo: methodName = "posts/photo"; break;
-				case PostType.Chat: methodName = "posts/chat"; break;
-				case PostType.All:
-				default: methodName = "posts"; break;
-			}
+            string methodName = null;
+            switch (type)
+            {
+                case PostType.Text: methodName = "posts/text"; break;
+                case PostType.Quote: methodName = "posts/quote"; break;
+                case PostType.Link: methodName = "posts/link"; break;
+                case PostType.Answer: methodName = "posts/answer"; break;
+                case PostType.Video: methodName = "posts/video"; break;
+                case PostType.Audio: methodName = "posts/audio"; break;
+                case PostType.Photo: methodName = "posts/photo"; break;
+                case PostType.Chat: methodName = "posts/chat"; break;
+                case PostType.All:
+                default: methodName = "posts"; break;
+            }
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("api_key", apiKey);
-			parameters.Add("offset", startIndex, 0);
-			parameters.Add("limit", count, 0);
-			parameters.Add("reblog_info", includeReblogInfo, false);
-			parameters.Add("notes_info", includeNotesInfo, false);
-			parameters.Add("filter", filter.ToString().ToLowerInvariant(), "html");
-			parameters.Add("tag", tag);
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("api_key", apiKey);
+            parameters.Add("offset", startIndex, 0);
+            parameters.Add("limit", count, 0);
+            parameters.Add("reblog_info", includeReblogInfo, false);
+            parameters.Add("notes_info", includeNotesInfo, false);
+            parameters.Add("filter", filter.ToString().ToLowerInvariant(), "html");
+            parameters.Add("tag", tag);
 
-			return CallApiMethodAsync<Posts>(
-				new BlogMethod(blogName, methodName, null, HttpMethod.Get, parameters),
-				CancellationToken.None);
-		}
+            return CallApiMethodAsync<Posts>(
+              new BlogMethod(blogName, methodName, null, HttpMethod.Get, parameters),
+              CancellationToken.None);
+        }
 
-		#endregion
+        #endregion
 
-		#region GetPostAsync
+        #region GetPostAsync
 
-		/// <summary>
-		/// Asynchronously retrieves a specific post by id.
-		/// </summary>
-		/// <param name="blogName">
-		/// Blog name to reference
-		/// </param>
-		/// <param name="id">
-		/// The id of the post to retrieve.
-		/// </param>
-		/// <param name="includeReblogInfo">
-		/// Whether or not to include reblog info with the posts.
-		/// </param>
-		/// <param name="includeNotesInfo">
-		/// Whether or not to include notes info with the posts.
-		/// </param>
-		/// <returns>
-		/// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-		/// carry a <see cref="BasePost"/> instance representing the desired post. Otherwise <see cref="Task.Exception"/> will carry a 
-		/// <see cref="TumblrException"/> if the post with the specified id cannot be found.
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="blogName"/> is <b>null</b>.
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <paramref name="blogName"/> is empty.
-		/// </exception>
-		/// <exception cref="System.ArgumentOutOfRangeException">
-		///	<paramref name="id"/> is less than 0.
-		/// </exception>
-		public Task<BasePost> GetPostAsync(string blogName, long id, bool includeReblogInfo = false, bool includeNotesInfo = false)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        /// <summary>
+        /// Asynchronously retrieves a specific post by id.
+        /// </summary>
+        /// <param name="blogName">
+        /// Blog name to reference
+        /// </param>
+        /// <param name="id">
+        /// The id of the post to retrieve.
+        /// </param>
+        /// <param name="includeReblogInfo">
+        /// Whether or not to include reblog info with the posts.
+        /// </param>
+        /// <param name="includeNotesInfo">
+        /// Whether or not to include notes info with the posts.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="BasePost"/> instance representing the desired post. Otherwise <see cref="Task.Exception"/> will carry a 
+        /// <see cref="TumblrException"/> if the post with the specified id cannot be found.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="blogName"/> is <b>null</b>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="blogName"/> is empty.
+        /// </exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        ///	<paramref name="id"/> is less than 0.
+        /// </exception>
+        public Task<BasePost> GetPostAsync(string blogName, long id, bool includeReblogInfo = false, bool includeNotesInfo = false)
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-		    if (blogName == null)
-		        throw new ArgumentNullException("blogName");
+            if (blogName == null)
+                throw new ArgumentNullException("blogName");
 
-		    if (blogName.Length == 0)
-		        throw new ArgumentException("Blog name cannot be empty.", "blogName");
+            if (blogName.Length == 0)
+                throw new ArgumentException("Blog name cannot be empty.", "blogName");
 
-			if (id < 0)
-				throw new ArgumentOutOfRangeException("id", "id must be greater or equal to zero.");
+            if (id < 0)
+                throw new ArgumentOutOfRangeException("id", "id must be greater or equal to zero.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("api_key", apiKey);
-			parameters.Add("id", id, 0);
-			parameters.Add("reblog_info", includeReblogInfo, false);
-			parameters.Add("notes_info", includeNotesInfo, false);
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("api_key", apiKey);
+            parameters.Add("id", id, 0);
+            parameters.Add("reblog_info", includeReblogInfo, false);
+            parameters.Add("notes_info", includeNotesInfo, false);
 
-			return CallApiMethodAsync<Posts, BasePost>(
-				new BlogMethod(blogName, "posts", null, HttpMethod.Get, parameters),
-				p => p.Result.FirstOrDefault(),
-				CancellationToken.None);
-		}
+            return CallApiMethodAsync<Posts, BasePost>(
+              new BlogMethod(blogName, "posts", null, HttpMethod.Get, parameters),
+              p => p.Result.FirstOrDefault(),
+              CancellationToken.None);
+        }
 
-    #endregion
+        #endregion
 
-    #region GetBlogLikesAsync
+        #region GetBlogLikesAsync
 
-    /// <summary>
-    /// Asynchronously retrieves the publicly exposed likes from a blog.
-    /// </summary>
-    /// <remarks>
-    /// See: http://www.tumblr.com/docs/en/api/v2#blog-likes
-    /// </remarks>
-    /// <param name="blogName">
-    /// The name of the blog.
-    /// </param>
-    /// <param name="startIndex">
-    /// The offset at which to start retrieving the likes. Use 0 to start retrieving from the latest like.
-    /// </param>
-    /// <param name="count">
-    /// The number of likes to retrieve. Must be between 1 and 20.
-    /// </param>
-    /// <param name="before">
-    /// The timestamp before when to retrieve likes. 
-    /// </param>
-    /// <param name="after">
-    /// The timestamp after when to retrieve likes. 
-    /// </param>
-    /// <returns>
-    /// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-    /// carry a <see cref="Likes"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
-    /// representing the error occurred during the call.
-    /// </returns>
-    /// <exception cref="ObjectDisposedException">
-    /// The object has been disposed.
-    /// </exception>
-    /// <exception cref="ArgumentNullException">
-    /// <paramref name="blogName"/> is <b>null</b>.
-    /// </exception>
-    /// <exception cref="ArgumentException">
-    /// <paramref name="blogName"/> is empty.
-    /// </exception>
-    /// <exception cref="System.ArgumentOutOfRangeException">
-    /// <list type="bullet">
-    /// <item>
-    ///		<description>
-    ///			<paramref name="startIndex"/> is less than 0.
-    ///		</description>
-    ///	</item>
-    ///	<item>
-    ///		<description>
-    ///			<paramref name="count"/> is less than 1 or greater than 20.
-    ///		</description>
-    ///	</item>
-    /// </list>
-    /// </exception>
-    public Task<Likes> GetBlogLikesAsync(string blogName, int startIndex = 0, int count = 20, DateTime? before = null, DateTime? after = null)
-    {
-      if (disposed)
-        throw new ObjectDisposedException("TumblrClient");
+        /// <summary>
+        /// Asynchronously retrieves the publicly exposed likes from a blog.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#blog-likes
+        /// </remarks>
+        /// <param name="blogName">
+        /// The name of the blog.
+        /// </param>
+        /// <param name="startIndex">
+        /// The offset at which to start retrieving the likes. Use 0 to start retrieving from the latest like.
+        /// </param>
+        /// <param name="count">
+        /// The number of likes to retrieve. Must be between 1 and 20.
+        /// </param>
+        /// <param name="before">
+        /// The timestamp before when to retrieve likes. 
+        /// </param>
+        /// <param name="after">
+        /// The timestamp after when to retrieve likes. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="Likes"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
+        /// representing the error occurred during the call.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="blogName"/> is <b>null</b>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="blogName"/> is empty.
+        /// </exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="startIndex"/> is less than 0.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="count"/> is less than 1 or greater than 20.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        public Task<Likes> GetBlogLikesAsync(string blogName, int startIndex = 0, int count = 20, DateTime? before = null, DateTime? after = null)
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-      if (blogName == null)
-        throw new ArgumentNullException("blogName");
+            if (blogName == null)
+                throw new ArgumentNullException("blogName");
 
-      if (blogName.Length == 0)
-        throw new ArgumentException("Blog name cannot be empty.", "blogName");
+            if (blogName.Length == 0)
+                throw new ArgumentException("Blog name cannot be empty.", "blogName");
 
-      if (startIndex < 0)
-        throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
 
-      if (count < 1 || count > 20)
-        throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
+            if (count < 1 || count > 20)
+                throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
 
-      MethodParameterSet parameters = new MethodParameterSet
+            MethodParameterSet parameters = new MethodParameterSet
       {
         { "api_key", apiKey },
         { "offset", startIndex, 0 },
@@ -342,511 +342,511 @@ namespace DontPanic.TumblrSharp.Client
         { "after", after.HasValue ? DateTimeHelper.ToTimestamp(after.Value).ToString() : null, null }
       };
 
-      return CallApiMethodAsync<Likes>(
-        new BlogMethod(blogName, "likes", null, HttpMethod.Get, parameters),
-        CancellationToken.None);
-    }
-    #endregion
+            return CallApiMethodAsync<Likes>(
+              new BlogMethod(blogName, "likes", null, HttpMethod.Get, parameters),
+              CancellationToken.None);
+        }
+        #endregion
 
-    #region GetFollowersAsync
-
-    /// <summary>
-    /// Asynchronously retrieves a blog's followers.
-    /// </summary>
-    /// <remarks>
-    /// See: http://www.tumblr.com/docs/en/api/v2#blog-followers
-    /// </remarks>
-    /// <param name="blogName">
-    /// The name of the blog.
-    /// </param>
-    /// <param name="startIndex">
-    /// The offset at which to start retrieving the followers. Use 0 to start retrieving from the latest follower.
-    /// </param>
-    /// <param name="count">
-    /// The number of followers to retrieve. Must be between 1 and 20.
-    /// </param>
-    /// <returns>
-    ///  A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-    /// carry a <see cref="Followers"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
-    /// A <see cref="Followers"/> instance.
-    /// </returns>
-    /// <exception cref="ObjectDisposedException">
-    /// The object has been disposed.
-    /// </exception>
-    /// <exception cref="ArgumentNullException">
-    /// <paramref name="blogName"/> is <b>null</b>.
-    /// </exception>
-    /// <exception cref="ArgumentException">
-    /// <paramref name="blogName"/> is empty.
-    /// </exception>
-    /// <exception cref="System.ArgumentOutOfRangeException">
-    /// <list type="bullet">
-    /// <item>
-    ///		<description>
-    ///			<paramref name="startIndex"/> is less than 0.
-    ///		</description>
-    ///	</item>
-    ///	<item>
-    ///		<description>
-    ///			<paramref name="count"/> is less than 1 or greater than 20.
-    ///		</description>
-    ///	</item>
-    /// </list>
-    /// </exception>
-    public Task<Followers> GetFollowersAsync(string blogName, int startIndex = 0, int count = 20)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
-
-			if (blogName == null)
-				throw new ArgumentNullException("blogName");
-
-			if (blogName.Length == 0)
-				throw new ArgumentException("Blog name cannot be empty.", "blogName");
-
-			if (startIndex < 0)
-				throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
-
-			if (count < 1 || count > 20)
-				throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
-
-			if (OAuthToken == null)
-				throw new InvalidOperationException("GetFollowersAsync method requires an OAuth token to be specified.");
-
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("offset", startIndex, 0);
-			parameters.Add("limit", count, 0);
-
-			return CallApiMethodAsync<Followers>(
-				new BlogMethod(blogName, "followers", OAuthToken, HttpMethod.Get, parameters),
-				CancellationToken.None);
-		}
-
-		#endregion
-
-		#region CreatePostAsync
-
-		/// <summary>
-		/// Asynchronously creates a new post.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#posting
-		/// </remarks>
-		/// <param name="blogName">
-		/// The name of the blog where to post to (must be one of the current user's blogs).
-		/// </param>
-		/// <param name="postData">
-		/// The data that represents the type of post to create. See <see cref="PostData"/> for how
-		/// to create various post types.
-		/// </param>
-		/// <returns>
-		/// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-		/// carry a <see cref="PostCreationInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
-		/// representing the error occurred during the call.
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="ArgumentNullException">
-		/// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="blogName"/> is <b>null</b>.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="postData"/> is <b>null</b>.
-		///		</description>
-		///	</item>
-		/// </list>
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <paramref name="blogName"/> is empty.
-		/// </exception>
-		/// <exception cref="InvalidOperationException">
-		/// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
-		/// </exception>
-		public Task<PostCreationInfo> CreatePostAsync(string blogName, PostData postData)
-		{
-			return CreatePostAsync(blogName, postData, CancellationToken.None);
-		}
-
-		/// <summary>
-		/// Asynchronously creates a new post.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#posting
-		/// </remarks>
-		/// <param name="blogName">
-		/// The name of the blog where to post to (must be one of the current user's blogs).
-		/// </param>
-		/// <param name="postData">
-		/// The data that represents the type of post to create. See <see cref="PostData"/> for how
-		/// to create various post types.
-		/// </param>
-		/// <param name="cancellationToken">
-		/// A <see cref="CancellationToken"/> that can be used to cancel the operation.
-		/// </param>
-		/// <returns>
-		/// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-		/// carry a <see cref="PostCreationInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
-		/// representing the error occurred during the call.
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="ArgumentNullException">
-		/// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="blogName"/> is <b>null</b>.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="postData"/> is <b>null</b>.
-		///		</description>
-		///	</item>
-		/// </list>
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <paramref name="blogName"/> is empty.
-		/// </exception>
-		/// <exception cref="InvalidOperationException">
-		/// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
-		/// </exception>
-		public Task<PostCreationInfo> CreatePostAsync(string blogName, PostData postData, CancellationToken cancellationToken)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
-
-			if (blogName == null)
-				throw new ArgumentNullException("blogName");
-
-			if (blogName.Length == 0)
-				throw new ArgumentException("Blog name cannot be empty.", "blogName");
-
-			if (postData == null)
-				throw new ArgumentNullException("postData");
-
-			if (OAuthToken == null)
-				throw new InvalidOperationException("CreatePostAsync method requires an OAuth token to be specified.");
-
-			return CallApiMethodAsync<PostCreationInfo>(
-				new BlogMethod(blogName, "post", OAuthToken, HttpMethod.Post, postData.ToMethodParameterSet()),
-				cancellationToken);
-		}
-
-		#endregion
-
-		#region EditPostAsync
-
-		/// <summary>
-		/// Asynchronously edits an existing post.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#editing
-		/// </remarks>
-		/// <param name="blogName">
-		/// The name of the blog where the post to edit is (must be one of the current user's blogs).
-		/// </param>
-		/// <param name="postId">
-		/// The identifier of the post to edit.
-		/// </param>
-		/// <param name="postData">
-		/// The data that represents the updated information for the post. See <see cref="PostData"/> for how
-		/// to create various post types.
-		/// </param>
-		/// <returns>
-		/// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-		/// carry a <see cref="PostCreationInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
-		/// representing the error occurred during the call.
-		/// </returns>
-		/// <exception cref="ArgumentNullException">
-		/// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="blogName"/> is <b>null</b>.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="postData"/> is <b>null</b>.
-		///		</description>
-		///	</item>
-		/// </list>
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="blogName"/> is empty.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="postId"/> is less than 0.
-		///		</description>
-		///	</item>
-		/// </list>
-		/// </exception>
-		/// <exception cref="InvalidOperationException">
-		/// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
-		/// </exception>
-		public Task<PostCreationInfo> EditPostAsync(string blogName, long postId, PostData postData)
-		{
-			return EditPostAsync(blogName, postId, postData, CancellationToken.None);
-		}
-
-		/// <summary>
-		/// Asynchronously edits an existing post.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#editing
-		/// </remarks>
-		/// <param name="blogName">
-		/// The name of the blog where the post to edit is (must be one of the current user's blogs).
-		/// </param>
-		/// <param name="postId">
-		/// The identifier of the post to edit.
-		/// </param>
-		/// <param name="postData">
-		/// The data that represents the updated information for the post. See <see cref="PostData"/> for how
-		/// to create various post types.
-		/// </param>
-		/// <param name="cancellationToken">
-		/// A <see cref="CancellationToken"/> that can be used to cancel the operation.
-		/// </param>
-		/// <returns>
-		/// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-		/// carry a <see cref="PostCreationInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
-		/// representing the error occurred during the call.
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="ArgumentNullException">
-		/// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="blogName"/> is <b>null</b>.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="postData"/> is <b>null</b>.
-		///		</description>
-		///	</item>
-		/// </list>
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="blogName"/> is empty.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="postId"/> is less than 0.
-		///		</description>
-		///	</item>
-		/// </list>
-		/// </exception>
-		/// <exception cref="InvalidOperationException">
-		/// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
-		/// </exception>
-		public Task<PostCreationInfo> EditPostAsync(string blogName, long postId, PostData postData, CancellationToken cancellationToken)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
-
-			if (blogName == null)
-				throw new ArgumentNullException("blogName");
-
-			if (blogName.Length == 0)
-				throw new ArgumentException("Blog name cannot be empty.", "blogName");
-
-			if (postId < 0)
-				throw new ArgumentOutOfRangeException("postId", "Post ID must be greater or equal to zero.");
-
-			if (postData == null)
-				throw new ArgumentNullException("postData");
-
-			if (OAuthToken == null)
-				throw new InvalidOperationException("EditPostAsync method requires an OAuth token to be specified.");
-
-			var parameters = postData.ToMethodParameterSet();
-			parameters.Add("id", postId);
-
-			return CallApiMethodAsync<PostCreationInfo>(
-				new BlogMethod(blogName, "post/edit", OAuthToken, HttpMethod.Post, parameters),
-				CancellationToken.None);
-		}
-
-		#endregion
-
-		#region ReblogAsync
-
-		/// <summary>
-		/// Asynchronously reblogs a post.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#reblogging
-		/// </remarks>
-		/// <param name="blogName">
-		/// The name of the blog where to reblog the psot (must be one of the current user's blogs).
-		/// </param>
-		/// <param name="postId">
-		/// The identifier of the post to reblog.
-		/// </param>
-		/// <param name="reblogKey">
-		/// The post reblog key.
-		/// </param>
-		/// <param name="comment">
-		/// An optional comment to add to the reblog.
-		/// </param>
-		/// <returns>
-		/// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-		/// carry a <see cref="PostCreationInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
-		/// representing the error occurred during the call.
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="ArgumentNullException">
-		/// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="blogName"/> is <b>null</b>.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="reblogKey"/> is <b>null</b>.
-		///		</description>
-		///	</item>
-		/// </list>
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// /// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="blogName"/> is empty.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="reblogKey"/> is empty.
-		///		</description>
-		///	</item>
-		/// </list>
-		/// </exception>
-		/// <exception cref="InvalidOperationException">
-		/// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
-		/// </exception>
-		public Task<PostCreationInfo> ReblogAsync(string blogName, long postId, string reblogKey, string comment = null)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
-
-			if (blogName == null)
-				throw new ArgumentNullException("blogName");
-
-			if (blogName.Length == 0)
-				throw new ArgumentException("Blog name cannot be empty.", "blogName");
-
-			if (postId <= 0)
-				throw new ArgumentException("Post ID must be greater than 0.", "postId");
-
-			if (reblogKey == null)
-				throw new ArgumentNullException("reblogKey");
-
-			if (reblogKey.Length == 0)
-				throw new ArgumentException("reblogKey cannot be empty.", "reblogKey");
-
-			if (OAuthToken == null)
-				throw new InvalidOperationException("ReblogAsync method requires an OAuth token to be specified.");
-
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("id", postId);
-			parameters.Add("reblog_key", reblogKey);
-			parameters.Add("comment", comment, null);
-
-			return CallApiMethodAsync<PostCreationInfo>(
-				new BlogMethod(blogName, "post/reblog", OAuthToken, HttpMethod.Post, parameters),
-				CancellationToken.None);
-		}
+        #region GetFollowersAsync
 
         /// <summary>
-		/// Asynchronously reblogs a post.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#reblogging
-		/// </remarks>
-		/// <param name="blogName">
-		/// The name of the blog where to reblog the psot (must be one of the current user's blogs).
-		/// </param>
-		/// <param name="postId">
-		/// The identifier of the post to reblog.
-		/// </param>
-		/// <param name="reblogKey">
-		/// The post reblog key.
-		/// </param>
-		/// <param name="comment">
-		/// An optional comment to add to the reblog.
-		/// </param>
+        /// Asynchronously retrieves a blog's followers.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#blog-followers
+        /// </remarks>
+        /// <param name="blogName">
+        /// The name of the blog.
+        /// </param>
+        /// <param name="startIndex">
+        /// The offset at which to start retrieving the followers. Use 0 to start retrieving from the latest follower.
+        /// </param>
+        /// <param name="count">
+        /// The number of followers to retrieve. Must be between 1 and 20.
+        /// </param>
+        /// <returns>
+        ///  A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="Followers"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
+        /// A <see cref="Followers"/> instance.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="blogName"/> is <b>null</b>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="blogName"/> is empty.
+        /// </exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="startIndex"/> is less than 0.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="count"/> is less than 1 or greater than 20.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        public Task<Followers> GetFollowersAsync(string blogName, int startIndex = 0, int count = 20)
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
+
+            if (blogName == null)
+                throw new ArgumentNullException("blogName");
+
+            if (blogName.Length == 0)
+                throw new ArgumentException("Blog name cannot be empty.", "blogName");
+
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
+
+            if (count < 1 || count > 20)
+                throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
+
+            if (OAuthToken == null)
+                throw new InvalidOperationException("GetFollowersAsync method requires an OAuth token to be specified.");
+
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("offset", startIndex, 0);
+            parameters.Add("limit", count, 0);
+
+            return CallApiMethodAsync<Followers>(
+              new BlogMethod(blogName, "followers", OAuthToken, HttpMethod.Get, parameters),
+              CancellationToken.None);
+        }
+
+        #endregion
+
+        #region CreatePostAsync
+
+        /// <summary>
+        /// Asynchronously creates a new post.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#posting
+        /// </remarks>
+        /// <param name="blogName">
+        /// The name of the blog where to post to (must be one of the current user's blogs).
+        /// </param>
+        /// <param name="postData">
+        /// The data that represents the type of post to create. See <see cref="PostData"/> for how
+        /// to create various post types.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="PostCreationInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
+        /// representing the error occurred during the call.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="blogName"/> is <b>null</b>.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="postData"/> is <b>null</b>.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="blogName"/> is empty.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
+        /// </exception>
+        public Task<PostCreationInfo> CreatePostAsync(string blogName, PostData postData)
+        {
+            return CreatePostAsync(blogName, postData, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously creates a new post.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#posting
+        /// </remarks>
+        /// <param name="blogName">
+        /// The name of the blog where to post to (must be one of the current user's blogs).
+        /// </param>
+        /// <param name="postData">
+        /// The data that represents the type of post to create. See <see cref="PostData"/> for how
+        /// to create various post types.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> that can be used to cancel the operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="PostCreationInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
+        /// representing the error occurred during the call.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="blogName"/> is <b>null</b>.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="postData"/> is <b>null</b>.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="blogName"/> is empty.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
+        /// </exception>
+        public Task<PostCreationInfo> CreatePostAsync(string blogName, PostData postData, CancellationToken cancellationToken)
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
+
+            if (blogName == null)
+                throw new ArgumentNullException("blogName");
+
+            if (blogName.Length == 0)
+                throw new ArgumentException("Blog name cannot be empty.", "blogName");
+
+            if (postData == null)
+                throw new ArgumentNullException("postData");
+
+            if (OAuthToken == null)
+                throw new InvalidOperationException("CreatePostAsync method requires an OAuth token to be specified.");
+
+            return CallApiMethodAsync<PostCreationInfo>(
+              new BlogMethod(blogName, "post", OAuthToken, HttpMethod.Post, postData.ToMethodParameterSet()),
+              cancellationToken);
+        }
+
+        #endregion
+
+        #region EditPostAsync
+
+        /// <summary>
+        /// Asynchronously edits an existing post.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#editing
+        /// </remarks>
+        /// <param name="blogName">
+        /// The name of the blog where the post to edit is (must be one of the current user's blogs).
+        /// </param>
+        /// <param name="postId">
+        /// The identifier of the post to edit.
+        /// </param>
+        /// <param name="postData">
+        /// The data that represents the updated information for the post. See <see cref="PostData"/> for how
+        /// to create various post types.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="PostCreationInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
+        /// representing the error occurred during the call.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="blogName"/> is <b>null</b>.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="postData"/> is <b>null</b>.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="blogName"/> is empty.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="postId"/> is less than 0.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
+        /// </exception>
+        public Task<PostCreationInfo> EditPostAsync(string blogName, long postId, PostData postData)
+        {
+            return EditPostAsync(blogName, postId, postData, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously edits an existing post.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#editing
+        /// </remarks>
+        /// <param name="blogName">
+        /// The name of the blog where the post to edit is (must be one of the current user's blogs).
+        /// </param>
+        /// <param name="postId">
+        /// The identifier of the post to edit.
+        /// </param>
+        /// <param name="postData">
+        /// The data that represents the updated information for the post. See <see cref="PostData"/> for how
+        /// to create various post types.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> that can be used to cancel the operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="PostCreationInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
+        /// representing the error occurred during the call.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="blogName"/> is <b>null</b>.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="postData"/> is <b>null</b>.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="blogName"/> is empty.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="postId"/> is less than 0.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
+        /// </exception>
+        public Task<PostCreationInfo> EditPostAsync(string blogName, long postId, PostData postData, CancellationToken cancellationToken)
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
+
+            if (blogName == null)
+                throw new ArgumentNullException("blogName");
+
+            if (blogName.Length == 0)
+                throw new ArgumentException("Blog name cannot be empty.", "blogName");
+
+            if (postId < 0)
+                throw new ArgumentOutOfRangeException("postId", "Post ID must be greater or equal to zero.");
+
+            if (postData == null)
+                throw new ArgumentNullException("postData");
+
+            if (OAuthToken == null)
+                throw new InvalidOperationException("EditPostAsync method requires an OAuth token to be specified.");
+
+            var parameters = postData.ToMethodParameterSet();
+            parameters.Add("id", postId);
+
+            return CallApiMethodAsync<PostCreationInfo>(
+              new BlogMethod(blogName, "post/edit", OAuthToken, HttpMethod.Post, parameters),
+              CancellationToken.None);
+        }
+
+        #endregion
+
+        #region ReblogAsync
+
+        /// <summary>
+        /// Asynchronously reblogs a post.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#reblogging
+        /// </remarks>
+        /// <param name="blogName">
+        /// The name of the blog where to reblog the psot (must be one of the current user's blogs).
+        /// </param>
+        /// <param name="postId">
+        /// The identifier of the post to reblog.
+        /// </param>
+        /// <param name="reblogKey">
+        /// The post reblog key.
+        /// </param>
+        /// <param name="comment">
+        /// An optional comment to add to the reblog.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="PostCreationInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
+        /// representing the error occurred during the call.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="blogName"/> is <b>null</b>.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="reblogKey"/> is <b>null</b>.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="blogName"/> is empty.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="reblogKey"/> is empty.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
+        /// </exception>
+        public Task<PostCreationInfo> ReblogAsync(string blogName, long postId, string reblogKey, string comment = null)
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
+
+            if (blogName == null)
+                throw new ArgumentNullException("blogName");
+
+            if (blogName.Length == 0)
+                throw new ArgumentException("Blog name cannot be empty.", "blogName");
+
+            if (postId <= 0)
+                throw new ArgumentException("Post ID must be greater than 0.", "postId");
+
+            if (reblogKey == null)
+                throw new ArgumentNullException("reblogKey");
+
+            if (reblogKey.Length == 0)
+                throw new ArgumentException("reblogKey cannot be empty.", "reblogKey");
+
+            if (OAuthToken == null)
+                throw new InvalidOperationException("ReblogAsync method requires an OAuth token to be specified.");
+
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("id", postId);
+            parameters.Add("reblog_key", reblogKey);
+            parameters.Add("comment", comment, null);
+
+            return CallApiMethodAsync<PostCreationInfo>(
+              new BlogMethod(blogName, "post/reblog", OAuthToken, HttpMethod.Post, parameters),
+              CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously reblogs a post.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#reblogging
+        /// </remarks>
+        /// <param name="blogName">
+        /// The name of the blog where to reblog the psot (must be one of the current user's blogs).
+        /// </param>
+        /// <param name="postId">
+        /// The identifier of the post to reblog.
+        /// </param>
+        /// <param name="reblogKey">
+        /// The post reblog key.
+        /// </param>
+        /// <param name="comment">
+        /// An optional comment to add to the reblog.
+        /// </param>
         /// <param name="state">
         /// Post creation state
         /// </param>
         /// <param name="publish_On">
         /// if state is <see cref="PostCreationState.Queue"/> is this the publishingtime 
         /// </param>
-		/// <returns>
-		/// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-		/// carry a <see cref="PostCreationInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
-		/// representing the error occurred during the call.
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="ArgumentNullException">
-		/// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="blogName"/> is <b>null</b>.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="reblogKey"/> is <b>null</b>.
-		///		</description>
-		///	</item>
-		/// </list>
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// /// <list type="bullet">
-		/// <item>
-		///		<description>
-		///			<paramref name="blogName"/> is empty.
-		///		</description>
-		///	</item>
-		///	<item>
-		///		<description>
-		///			<paramref name="reblogKey"/> is empty.
-		///		</description>
-		///	</item>
+        /// <returns>
+        /// A <see cref="Task{T}"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="PostCreationInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry a <see cref="TumblrException"/>
+        /// representing the error occurred during the call.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="blogName"/> is <b>null</b>.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="reblogKey"/> is <b>null</b>.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="blogName"/> is empty.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="reblogKey"/> is empty.
+        ///		</description>
+        ///	</item>
         ///	<item>
         ///	    <description>
         ///	        <paramref name="publish_On"/> is in the past.
         ///	    </description>
         /// </item>
-		/// </list>
-		/// </exception>
-		/// <exception cref="InvalidOperationException">
-		/// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
-		/// </exception>
+        /// </list>
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
+        /// </exception>
         public Task<PostCreationInfo> ReblogAsync(string blogName, long postId, string reblogKey, PostCreationState state, DateTime? publish_On = null, string comment = null)
         {
             if (state == PostCreationState.Published)
@@ -956,35 +956,35 @@ namespace DontPanic.TumblrSharp.Client
         /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
         /// </exception>
         public Task<BasePost[]> GetQueuedPostsAsync(string blogName, long startIndex = 0, int count = 20, PostFilter filter = PostFilter.Html)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (blogName == null)
-				throw new ArgumentNullException("blogName");
+            if (blogName == null)
+                throw new ArgumentNullException("blogName");
 
-			if (blogName.Length == 0)
-				throw new ArgumentException("Blog name cannot be empty.", "blogName");
+            if (blogName.Length == 0)
+                throw new ArgumentException("Blog name cannot be empty.", "blogName");
 
-			if (startIndex < 0)
-				throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
 
-			if (count < 1 || count > 20)
-				throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
+            if (count < 1 || count > 20)
+                throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("GetQueuedPostsAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("GetQueuedPostsAsync method requires an OAuth token to be specified.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("offset", startIndex, 0);
-			parameters.Add("limit", count, 0);
-			parameters.Add("filter", filter.ToString().ToLowerInvariant(), "html");
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("offset", startIndex, 0);
+            parameters.Add("limit", count, 0);
+            parameters.Add("filter", filter.ToString().ToLowerInvariant(), "html");
 
-			return CallApiMethodAsync<PostCollection, BasePost[]>(
-				new BlogMethod(blogName, "posts/queue",OAuthToken, HttpMethod.Get, parameters),
-				r => r.Posts,
-				CancellationToken.None);
-		}
+            return CallApiMethodAsync<PostCollection, BasePost[]>(
+              new BlogMethod(blogName, "posts/queue", OAuthToken, HttpMethod.Get, parameters),
+              r => r.Posts,
+              CancellationToken.None);
+        }
 
         #endregion
 
@@ -1027,31 +1027,31 @@ namespace DontPanic.TumblrSharp.Client
         /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
         /// </exception>
         public Task<BasePost[]> GetDraftPostsAsync(string blogName, long sinceId = 0, PostFilter filter = PostFilter.Html)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (blogName == null)
-				throw new ArgumentNullException("blogName");
+            if (blogName == null)
+                throw new ArgumentNullException("blogName");
 
-			if (blogName.Length == 0)
-				throw new ArgumentException("Blog name cannot be empty.", "blogName");
+            if (blogName.Length == 0)
+                throw new ArgumentException("Blog name cannot be empty.", "blogName");
 
-			if (sinceId < 0)
-				throw new ArgumentOutOfRangeException("sinceId", "sinceId must be greater or equal to zero.");
+            if (sinceId < 0)
+                throw new ArgumentOutOfRangeException("sinceId", "sinceId must be greater or equal to zero.");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("GetDraftPostsAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("GetDraftPostsAsync method requires an OAuth token to be specified.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("since_id", sinceId, 0);
-			parameters.Add("filter", filter.ToString().ToLowerInvariant(), "html");
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("since_id", sinceId, 0);
+            parameters.Add("filter", filter.ToString().ToLowerInvariant(), "html");
 
-			return CallApiMethodAsync<PostCollection, BasePost[]>(
-				new BlogMethod(blogName, "posts/draft", OAuthToken, HttpMethod.Get, parameters),
-				r => r.Posts,
-				CancellationToken.None);
-		}
+            return CallApiMethodAsync<PostCollection, BasePost[]>(
+              new BlogMethod(blogName, "posts/draft", OAuthToken, HttpMethod.Get, parameters),
+              r => r.Posts,
+              CancellationToken.None);
+        }
 
         #endregion
 
@@ -1093,31 +1093,31 @@ namespace DontPanic.TumblrSharp.Client
         /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
         /// </exception>
         public Task<BasePost[]> GetSubmissionPostsAsync(string blogName, long startIndex = 0, PostFilter filter = PostFilter.Html)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (blogName == null)
-				throw new ArgumentNullException("blogName");
+            if (blogName == null)
+                throw new ArgumentNullException("blogName");
 
-			if (blogName.Length == 0)
-				throw new ArgumentException("Blog name cannot be empty.", "blogName");
+            if (blogName.Length == 0)
+                throw new ArgumentException("Blog name cannot be empty.", "blogName");
 
-			if (startIndex < 0)
-				throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("GetSubmissionPostsAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("GetSubmissionPostsAsync method requires an OAuth token to be specified.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("offset", startIndex);
-			parameters.Add("filter", filter.ToString().ToLowerInvariant(), "html");
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("offset", startIndex);
+            parameters.Add("filter", filter.ToString().ToLowerInvariant(), "html");
 
-			return CallApiMethodAsync<PostCollection, BasePost[]>(
-				new BlogMethod(blogName, "posts/submission", OAuthToken, HttpMethod.Get, parameters),
-				r => r.Posts,
-				CancellationToken.None);
-		}
+            return CallApiMethodAsync<PostCollection, BasePost[]>(
+              new BlogMethod(blogName, "posts/submission", OAuthToken, HttpMethod.Get, parameters),
+              r => r.Posts,
+              CancellationToken.None);
+        }
 
         #endregion
 
@@ -1155,68 +1155,68 @@ namespace DontPanic.TumblrSharp.Client
         /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
         /// </exception>
         public Task DeletePostAsync(string blogName, long postId)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (blogName == null)
-				throw new ArgumentNullException("blogName");
+            if (blogName == null)
+                throw new ArgumentNullException("blogName");
 
-			if (blogName.Length == 0)
-				throw new ArgumentException("Blog name cannot be empty.", "blogName");
+            if (blogName.Length == 0)
+                throw new ArgumentException("Blog name cannot be empty.", "blogName");
 
-			if (postId < 0)
-				throw new ArgumentOutOfRangeException("postId", "Post ID must be greater or equal to zero.");
+            if (postId < 0)
+                throw new ArgumentOutOfRangeException("postId", "Post ID must be greater or equal to zero.");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("DeletePostAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("DeletePostAsync method requires an OAuth token to be specified.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("id", postId);
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("id", postId);
 
-			return CallApiMethodNoResultAsync(
-				new BlogMethod(blogName, "post/delete", OAuthToken, HttpMethod.Post, parameters),
-				CancellationToken.None);
-		}
+            return CallApiMethodNoResultAsync(
+              new BlogMethod(blogName, "post/delete", OAuthToken, HttpMethod.Post, parameters),
+              CancellationToken.None);
+        }
 
-		#endregion
+        #endregion
 
-		#endregion
+        #endregion
 
-		#region User Methods
+        #region User Methods
 
-		#region GetUserInfoAsync
+        #region GetUserInfoAsync
 
-		/// <summary>
-		/// Asynchronously retrieves the user's account information that matches the OAuth credentials submitted with the request.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#user-methods
-		/// </remarks>
-		/// <returns>
-		/// A <see cref="Task"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-		/// carry a <see cref="UserInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry the <see cref="TumblrException"/>
-		/// generated during the call.
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="InvalidOperationException">
-		/// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
-		/// </exception>
-		public Task<UserInfo> GetUserInfoAsync()
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        /// <summary>
+        /// Asynchronously retrieves the user's account information that matches the OAuth credentials submitted with the request.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#user-methods
+        /// </remarks>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="UserInfo"/> instance. Otherwise <see cref="Task.Exception"/> will carry the <see cref="TumblrException"/>
+        /// generated during the call.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
+        /// </exception>
+        public Task<UserInfo> GetUserInfoAsync()
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("GetUserInfoAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("GetUserInfoAsync method requires an OAuth token to be specified.");
 
-			return CallApiMethodAsync<UserInfoResponse, UserInfo>(
-				new UserMethod("info", OAuthToken, HttpMethod.Get),
-				r => r.User,
-				CancellationToken.None);
-		}
+            return CallApiMethodAsync<UserInfoResponse, UserInfo>(
+              new UserMethod("info", OAuthToken, HttpMethod.Get),
+              r => r.User,
+              CancellationToken.None);
+        }
 
         #endregion
 
@@ -1260,90 +1260,90 @@ namespace DontPanic.TumblrSharp.Client
         /// </list>
         /// </exception>
         public Task<Following> GetFollowingAsync(long startIndex = 0, int count = 20)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (startIndex < 0)
-				throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
 
-			if (count <= 0 || count > 20)
-				throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
+            if (count <= 0 || count > 20)
+                throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("GetFollowingAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("GetFollowingAsync method requires an OAuth token to be specified.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("offset", startIndex, 0);
-			parameters.Add("limit", count, 0);
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("offset", startIndex, 0);
+            parameters.Add("limit", count, 0);
 
-			return CallApiMethodAsync<Following>(
-				new UserMethod("following", OAuthToken, HttpMethod.Get, parameters),
-				CancellationToken.None);
-		}
+            return CallApiMethodAsync<Following>(
+              new UserMethod("following", OAuthToken, HttpMethod.Get, parameters),
+              CancellationToken.None);
+        }
 
-    #endregion
+        #endregion
 
-    #region GetLikesAsync
+        #region GetLikesAsync
 
-    /// <summary>
-    /// Asynchronously retrieves the current user's likes.
-    /// </summary>
-    /// <remarks>
-    /// See: http://www.tumblr.com/docs/en/api/v2#m-ug-likes
-    /// </remarks>
-    /// <param name="startIndex">
-    /// The offset at which to start retrieving the likes. Use 0 to start retrieving from the latest like.
-    /// </param>
-    /// <param name="count">
-    /// The number of likes to retrieve. Must be between 1 and 20.
-    /// </param>
-    /// <param name="before">
-    /// The timestamp before when to retrieve likes. 
-    /// </param>
-    /// <param name="after">
-    /// The timestamp after when to retrieve likes. 
-    /// </param>
-    /// <returns>
-    /// A <see cref="Task"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
-    /// carry a <see cref="Likes"/> instance. Otherwise <see cref="Task.Exception"/> will carry the <see cref="TumblrException"/>
-    /// generated during the call.
-    /// </returns>
-    /// <exception cref="ObjectDisposedException">
-    /// The object has been disposed.
-    /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
-    /// </exception>
-    /// <exception cref="System.ArgumentOutOfRangeException">
-    /// <list type="bullet">
-    /// <item>
-    ///		<description>
-    ///			<paramref name="startIndex"/> is less than 0.
-    ///		</description>
-    ///	</item>
-    ///	<item>
-    ///		<description>
-    ///			<paramref name="count"/> is less than 1 or greater than 20.
-    ///		</description>
-    ///	</item>
-    /// </list>
-    /// </exception>
-    public Task<Likes> GetLikesAsync(long startIndex = 0, int count = 20, DateTime? before = null, DateTime? after = null)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        /// <summary>
+        /// Asynchronously retrieves the current user's likes.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#m-ug-likes
+        /// </remarks>
+        /// <param name="startIndex">
+        /// The offset at which to start retrieving the likes. Use 0 to start retrieving from the latest like.
+        /// </param>
+        /// <param name="count">
+        /// The number of likes to retrieve. Must be between 1 and 20.
+        /// </param>
+        /// <param name="before">
+        /// The timestamp before when to retrieve likes. 
+        /// </param>
+        /// <param name="after">
+        /// The timestamp after when to retrieve likes. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to track the operation. If the task succeeds, the <see cref="Task{T}.Result"/> will
+        /// carry a <see cref="Likes"/> instance. Otherwise <see cref="Task.Exception"/> will carry the <see cref="TumblrException"/>
+        /// generated during the call.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
+        /// </exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <list type="bullet">
+        /// <item>
+        ///		<description>
+        ///			<paramref name="startIndex"/> is less than 0.
+        ///		</description>
+        ///	</item>
+        ///	<item>
+        ///		<description>
+        ///			<paramref name="count"/> is less than 1 or greater than 20.
+        ///		</description>
+        ///	</item>
+        /// </list>
+        /// </exception>
+        public Task<Likes> GetLikesAsync(long startIndex = 0, int count = 20, DateTime? before = null, DateTime? after = null)
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (startIndex < 0)
-				throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
 
-			if (count <= 0 || count > 20)
-				throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
+            if (count <= 0 || count > 20)
+                throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("GetLikesAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("GetLikesAsync method requires an OAuth token to be specified.");
 
-      MethodParameterSet parameters = new MethodParameterSet
+            MethodParameterSet parameters = new MethodParameterSet
       {
         { "offset", startIndex, 0 },
         { "limit", count, 0 },
@@ -1351,10 +1351,10 @@ namespace DontPanic.TumblrSharp.Client
         { "after", after.HasValue ? DateTimeHelper.ToTimestamp(after.Value).ToString() : null, null }
       };
 
-      return CallApiMethodAsync<Likes>(
-				new UserMethod("likes", OAuthToken, HttpMethod.Get, parameters),
-				CancellationToken.None);
-		}
+            return CallApiMethodAsync<Likes>(
+              new UserMethod("likes", OAuthToken, HttpMethod.Get, parameters),
+              CancellationToken.None);
+        }
 
         #endregion
 
@@ -1392,30 +1392,30 @@ namespace DontPanic.TumblrSharp.Client
         /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
         /// </exception>
         public Task LikeAsync(long postId, string reblogKey)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (postId <= 0)
-				throw new ArgumentOutOfRangeException("Post ID must be greater than 0.", "postId");
+            if (postId <= 0)
+                throw new ArgumentOutOfRangeException("Post ID must be greater than 0.", "postId");
 
-			if (reblogKey == null)
-				throw new ArgumentNullException("reblogKey");
+            if (reblogKey == null)
+                throw new ArgumentNullException("reblogKey");
 
-			if (reblogKey.Length == 0)
-				throw new ArgumentException("reblogKey cannot be empty.", "reblogKey");
+            if (reblogKey.Length == 0)
+                throw new ArgumentException("reblogKey cannot be empty.", "reblogKey");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("LikeAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("LikeAsync method requires an OAuth token to be specified.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("id", postId);
-			parameters.Add("reblog_key", reblogKey);
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("id", postId);
+            parameters.Add("reblog_key", reblogKey);
 
-			return CallApiMethodNoResultAsync(
-				new UserMethod("like", OAuthToken, HttpMethod.Post, parameters),
-				CancellationToken.None);
-		}
+            return CallApiMethodNoResultAsync(
+              new UserMethod("like", OAuthToken, HttpMethod.Post, parameters),
+              CancellationToken.None);
+        }
 
         #endregion
 
@@ -1453,132 +1453,132 @@ namespace DontPanic.TumblrSharp.Client
         /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
         /// </exception>
         public Task UnlikeAsync(long postId, string reblogKey)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (postId <= 0)
-				throw new ArgumentException("Post ID must be greater than 0.", "postId");
+            if (postId <= 0)
+                throw new ArgumentException("Post ID must be greater than 0.", "postId");
 
-			if (reblogKey == null)
-				throw new ArgumentNullException("reblogKey");
+            if (reblogKey == null)
+                throw new ArgumentNullException("reblogKey");
 
-			if (reblogKey.Length == 0)
-				throw new ArgumentException("reblogKey cannot be empty.", "reblogKey");
+            if (reblogKey.Length == 0)
+                throw new ArgumentException("reblogKey cannot be empty.", "reblogKey");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("UnlikeAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("UnlikeAsync method requires an OAuth token to be specified.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("id", postId);
-			parameters.Add("reblog_key", reblogKey);
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("id", postId);
+            parameters.Add("reblog_key", reblogKey);
 
-			return CallApiMethodNoResultAsync(
-				new UserMethod("unlike", OAuthToken, HttpMethod.Post, parameters),
-				CancellationToken.None);
-		}
+            return CallApiMethodNoResultAsync(
+              new UserMethod("unlike", OAuthToken, HttpMethod.Post, parameters),
+              CancellationToken.None);
+        }
 
-		#endregion
+        #endregion
 
-		#region FollowAsync
+        #region FollowAsync
 
-		/// <summary>
-		/// Asynchronously follows a blog.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#m-up-follow
-		/// </remarks>
-		/// <param name="blogUrl">
-		/// The url of the blog to follow.
-		/// </param>
-		/// <returns>
-		/// A <see cref="Task{T}"/> that can be used to track the operation. If the task fails, <see cref="Task.Exception"/> 
-		/// will carry a <see cref="TumblrException"/>
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="blogUrl"/> is <b>null</b>.
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <paramref name="blogUrl"/> is empty.
-		/// </exception>
-		/// <exception cref="InvalidOperationException">
-		/// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
-		/// </exception>
-		public Task FollowAsync(string blogUrl)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        /// <summary>
+        /// Asynchronously follows a blog.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#m-up-follow
+        /// </remarks>
+        /// <param name="blogUrl">
+        /// The url of the blog to follow.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{T}"/> that can be used to track the operation. If the task fails, <see cref="Task.Exception"/> 
+        /// will carry a <see cref="TumblrException"/>
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="blogUrl"/> is <b>null</b>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="blogUrl"/> is empty.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
+        /// </exception>
+        public Task FollowAsync(string blogUrl)
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (blogUrl == null)
-				throw new ArgumentNullException("blogUrl");
+            if (blogUrl == null)
+                throw new ArgumentNullException("blogUrl");
 
-			if (blogUrl.Length == 0)
-				throw new ArgumentException("Blog url cannot be empty.", "blogUrl");
+            if (blogUrl.Length == 0)
+                throw new ArgumentException("Blog url cannot be empty.", "blogUrl");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("FollowAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("FollowAsync method requires an OAuth token to be specified.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("url", blogUrl);
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("url", blogUrl);
 
-			return CallApiMethodNoResultAsync(
-				new UserMethod("follow", OAuthToken, HttpMethod.Post, parameters),
-				CancellationToken.None);
-		}
+            return CallApiMethodNoResultAsync(
+              new UserMethod("follow", OAuthToken, HttpMethod.Post, parameters),
+              CancellationToken.None);
+        }
 
-		#endregion
+        #endregion
 
-		#region UnfollowAsync
+        #region UnfollowAsync
 
-		/// <summary>
-		/// Asynchronously unfollows a blog.
-		/// </summary>
-		/// <remarks>
-		/// See: http://www.tumblr.com/docs/en/api/v2#m-up-unfollow
-		/// </remarks>
-		/// <param name="blogUrl">
-		/// The url of the blog to unfollow.
-		/// </param>
-		/// <returns>
-		/// A <see cref="Task{T}"/> that can be used to track the operation. If the task fails, <see cref="Task.Exception"/> 
-		/// will carry a <see cref="TumblrException"/>
-		/// </returns>
-		/// <exception cref="ObjectDisposedException">
-		/// The object has been disposed.
-		/// </exception>
-		/// <exception cref="ArgumentNullException">
-		/// <paramref name="blogUrl"/> is <b>null</b>.
-		/// </exception>
-		/// <exception cref="ArgumentException">
-		/// <paramref name="blogUrl"/> is empty.
-		/// </exception>
-		/// <exception cref="InvalidOperationException">
-		/// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
-		/// </exception>
-		public Task UnfollowAsync(string blogUrl)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        /// <summary>
+        /// Asynchronously unfollows a blog.
+        /// </summary>
+        /// <remarks>
+        /// See: http://www.tumblr.com/docs/en/api/v2#m-up-unfollow
+        /// </remarks>
+        /// <param name="blogUrl">
+        /// The url of the blog to unfollow.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{T}"/> that can be used to track the operation. If the task fails, <see cref="Task.Exception"/> 
+        /// will carry a <see cref="TumblrException"/>
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        /// The object has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="blogUrl"/> is <b>null</b>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="blogUrl"/> is empty.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// This <see cref="TumblrClient"/> instance does not have an OAuth token specified.
+        /// </exception>
+        public Task UnfollowAsync(string blogUrl)
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (blogUrl == null)
-				throw new ArgumentNullException("blogUrl");
+            if (blogUrl == null)
+                throw new ArgumentNullException("blogUrl");
 
-			if (blogUrl.Length == 0)
-				throw new ArgumentException("Blog url cannot be empty.", "blogUrl");
+            if (blogUrl.Length == 0)
+                throw new ArgumentException("Blog url cannot be empty.", "blogUrl");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("UnfollowAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("UnfollowAsync method requires an OAuth token to be specified.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("url", blogUrl);
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("url", blogUrl);
 
-			return CallApiMethodNoResultAsync(
-				new UserMethod("unfollow", OAuthToken, HttpMethod.Post, parameters),
-				CancellationToken.None);
-		}
+            return CallApiMethodNoResultAsync(
+              new UserMethod("unfollow", OAuthToken, HttpMethod.Post, parameters),
+              CancellationToken.None);
+        }
 
         #endregion
 
@@ -1623,31 +1623,31 @@ namespace DontPanic.TumblrSharp.Client
         /// <paramref name="count"/> is less than 1 or greater than 20.
         /// </exception>
         public Task<BasePost[]> GetTaggedPostsAsync(string tag, DateTime? before = null, int count = 20, PostFilter filter = PostFilter.Html)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (tag == null)
-				throw new ArgumentNullException("tag");
+            if (tag == null)
+                throw new ArgumentNullException("tag");
 
-			if (tag.Length == 0)
-				throw new ArgumentException("Tag cannot be empty.", "tag");
+            if (tag.Length == 0)
+                throw new ArgumentException("Tag cannot be empty.", "tag");
 
-			if (count < 1 || count > 20)
-				throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
+            if (count < 1 || count > 20)
+                throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("api_key", apiKey);
-			parameters.Add("tag", tag);
-			parameters.Add("before", before.HasValue ? DateTimeHelper.ToTimestamp(before.Value).ToString() : null, null);
-			parameters.Add("limit", count, 0);
-			parameters.Add("filter", filter.ToString().ToLowerInvariant(), "html");
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("api_key", apiKey);
+            parameters.Add("tag", tag);
+            parameters.Add("before", before.HasValue ? DateTimeHelper.ToTimestamp(before.Value).ToString() : null, null);
+            parameters.Add("limit", count, 0);
+            parameters.Add("filter", filter.ToString().ToLowerInvariant(), "html");
 
-			return CallApiMethodAsync<BasePost[]>(
-				new ApiMethod("https://api.tumblr.com/v2/tagged", OAuthToken, HttpMethod.Get, parameters),
-				CancellationToken.None,
-				new JsonConverter[] { new PostArrayConverter() });
-		}
+            return CallApiMethodAsync<BasePost[]>(
+              new ApiMethod("https://api.tumblr.com/v2/tagged", OAuthToken, HttpMethod.Get, parameters),
+              CancellationToken.None,
+              new JsonConverter[] { new PostArrayConverter() });
+        }
 
         #endregion
 
@@ -1707,35 +1707,35 @@ namespace DontPanic.TumblrSharp.Client
         /// </list>
         /// </exception>
         public Task<BasePost[]> GetDashboardPostsAsync(long sinceId = 0, long startIndex = 0, int count = 20, PostType type = PostType.All, bool includeReblogInfo = false, bool includeNotesInfo = false)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (sinceId < 0)
-				throw new ArgumentOutOfRangeException("sinceId", "sinceId must be greater or equal to zero.");
+            if (sinceId < 0)
+                throw new ArgumentOutOfRangeException("sinceId", "sinceId must be greater or equal to zero.");
 
-			if (startIndex < 0)
-				throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
 
-			if (count < 1 || count > 20)
-				throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
+            if (count < 1 || count > 20)
+                throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("GetDashboardPostsAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("GetDashboardPostsAsync method requires an OAuth token to be specified.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("type", type.ToString().ToLowerInvariant(), "all");
-			parameters.Add("since_id", sinceId, 0);
-			parameters.Add("offset", startIndex, 0);
-			parameters.Add("limit", count, 0);
-			parameters.Add("reblog_info", includeReblogInfo, false);
-			parameters.Add("notes_info", includeNotesInfo, false);
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("type", type.ToString().ToLowerInvariant(), "all");
+            parameters.Add("since_id", sinceId, 0);
+            parameters.Add("offset", startIndex, 0);
+            parameters.Add("limit", count, 0);
+            parameters.Add("reblog_info", includeReblogInfo, false);
+            parameters.Add("notes_info", includeNotesInfo, false);
 
-			return CallApiMethodAsync<PostCollection, BasePost[]>(
-				new UserMethod("dashboard", OAuthToken, HttpMethod.Get, parameters),
-				r => r.Posts,
-				CancellationToken.None);
-		}
+            return CallApiMethodAsync<PostCollection, BasePost[]>(
+              new UserMethod("dashboard", OAuthToken, HttpMethod.Get, parameters),
+              r => r.Posts,
+              CancellationToken.None);
+        }
 
         /// <summary>
         /// Asynchronously retrieves posts from the current user's dashboard.
@@ -1800,7 +1800,7 @@ namespace DontPanic.TumblrSharp.Client
 
             if (Id < 0)
                 throw new ArgumentOutOfRangeException("ID", "Id must be greater or equal to zero.");
-            
+
             if (startIndex < 0)
                 throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
 
@@ -1823,7 +1823,7 @@ namespace DontPanic.TumblrSharp.Client
                     parameters.Add("after_id", Id, 0);
                     break;
             }
-            
+
             parameters.Add("offset", startIndex, 0);
             parameters.Add("limit", count, 0);
             parameters.Add("reblog_info", includeReblogInfo, false);
@@ -1877,47 +1877,47 @@ namespace DontPanic.TumblrSharp.Client
         /// </list>
         /// </exception>
         public Task<Likes> GetUserLikesAsync(int startIndex = 0, int count = 20)
-		{
-			if (disposed)
-				throw new ObjectDisposedException("TumblrClient");
+        {
+            if (disposed)
+                throw new ObjectDisposedException("TumblrClient");
 
-			if (startIndex < 0)
-				throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException("startIndex", "startIndex must be greater or equal to zero.");
 
-			if (count < 1 || count > 20)
-				throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
+            if (count < 1 || count > 20)
+                throw new ArgumentOutOfRangeException("count", "count must be between 1 and 20.");
 
-			if (OAuthToken == null)
-				throw new InvalidOperationException("GetBlogLikesAsync method requires an OAuth token to be specified.");
+            if (OAuthToken == null)
+                throw new InvalidOperationException("GetBlogLikesAsync method requires an OAuth token to be specified.");
 
-			MethodParameterSet parameters = new MethodParameterSet();
-			parameters.Add("offset", startIndex, 0);
-			parameters.Add("limit", count, 0);
+            MethodParameterSet parameters = new MethodParameterSet();
+            parameters.Add("offset", startIndex, 0);
+            parameters.Add("limit", count, 0);
 
-			return CallApiMethodAsync<Likes>(
-				new UserMethod("likes", OAuthToken, HttpMethod.Get, parameters),
-				CancellationToken.None);
-		}
-
-		#endregion
-
-		#endregion
+            return CallApiMethodAsync<Likes>(
+              new UserMethod("likes", OAuthToken, HttpMethod.Get, parameters),
+              CancellationToken.None);
+        }
 
         #endregion
 
-		#region IDisposable Implementation
+        #endregion
 
-		/// <summary>
-		/// Disposes of the object.
-		/// </summary>
-		/// <param name="disposing">
-		/// <b>true</b> if managed resources have to be disposed; otherwise <b>false</b>.
-		/// </param>
-		protected override void Dispose(bool disposing)
-		{
-			disposed = true;
-			base.Dispose();
-		}
+        #endregion
+
+        #region IDisposable Implementation
+
+        /// <summary>
+        /// Disposes of the object.
+        /// </summary>
+        /// <param name="disposing">
+        /// <b>true</b> if managed resources have to be disposed; otherwise <b>false</b>.
+        /// </param>
+        protected override void Dispose(bool disposing)
+        {
+            disposed = true;
+            base.Dispose();
+        }
 
         #endregion
     }


### PR DESCRIPTION
Hi there. I enhanced the Get*LikesAsync methods to let the user provide a value for the "before" and "after" parameters, as per the API documentation.
Doing so, I damaged the indentation of the methods I worked on (i usually work with 2 spaces indentations). So I set VS back to the standard 4 spaces and refreshed the whole document. But a diff with the master now shows a bunch of changes, which I interpret as an artistic indentation in the original file.

